### PR TITLE
Add lock files to generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/client/pacakge-lock.json linguist-generated
+/server/Cargo.lock        linguist-generated


### PR DESCRIPTION
Pour éviter les revues de fichier généré, on utilise https://github.com/github/linguist
Pour l'instant, c'est pour les fichiers "lock".